### PR TITLE
Add Firefox support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Frame
 
-New-tab extension for Chrome
+New-tab extension for Chrome and Firefox
 
 <img src="screenshot.png" alt="screenshot" width="600px"/>
 
 ## Install
 
 - [**Chrome** extension](https://chrome.google.com/webstore/detail/frame/pimalalkfhkmnlhoapdlhilkghboiimc)
+- **Firefox** extension link will be provided soon.
 
 ## Contribute
 
@@ -20,7 +21,8 @@ Please follow the below steps:
 git clone https://github.com/ademilter/frame
 cd frame
 yarn    # Install dev dependencies
-yarn build  # Build the extension code so it's ready for the browser
+yarn build  # Build the extension code so it's ready for Chrome
+yarn build-firefox  # Build the extension code so it's ready for Firefox
 yarn serve  # Listen for file changes and automatically rebuild
 ```
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
+    "build-firefox": "VUE_APP_PLATFORM=firefox vue-cli-service build",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,6 +3,12 @@
   "version": "1.2",
   "description": "",
   "manifest_version": 2,
+  "applications": {
+      "gecko": {
+        "id": "Frame-ademilter@mozilla.org",
+        "strict_min_version": "53a1"
+      }
+  },
   "chrome_url_overrides": {
     "newtab": "index.html"
   },
@@ -27,6 +33,8 @@
     "http://*/*",
     "https://*/*",
     "http://calendar.google.com/calendar/*",
-    "https://calendar.google.com/calendar/*"
+    "https://calendar.google.com/calendar/*",
+    "*://www.googleapis.com/*",
+    "*://accounts.google.com/*"
   ]
 }

--- a/src/components/calendar/index.vue
+++ b/src/components/calendar/index.vue
@@ -84,15 +84,19 @@
         this.$refs.ps.update()
       },
 
+      /* global chrome */
       Notification () {
-        Notification.requestPermission(function (permission) {
-        })
         const result = this.eventsByDateGroup
 
-        for (var anEvent in result) {
+        for (const anEvent in result) {
           if (this.$moment(anEvent).format('dddd, D MMMM YYYY') === this.date) {
             if (this.$moment(anEvent).fromNow() === '30 dakika sonra') {
-               new Notification('Yaklaşan etkinlik: ' + result[anEvent][0].summary + ' \n 30 dakika sonra')
+              chrome.notifications.create(null, {
+                'type': 'basic',
+                'iconUrl': 'icon-48.png',
+                'title': 'Yaklaşan etkinlik',
+                'message': result[anEvent][0].summary + ' \n 30 dakika sonra'
+              })
             }
           }
         }

--- a/src/components/note/note.vue
+++ b/src/components/note/note.vue
@@ -94,6 +94,7 @@
     padding-left: 30px;
     padding-right: 30px;
     position: relative;
+    background-color: var(--color-note);
 
     &:not(:last-child):after {
       content: "";

--- a/src/components/note/note.vue
+++ b/src/components/note/note.vue
@@ -1,8 +1,7 @@
 <template lang="pug">
   .note
 
-    button.handle(
-    type="button")
+    .handle
       icon-drag
 
     button.remove(

--- a/src/components/task/task.vue
+++ b/src/components/task/task.vue
@@ -1,8 +1,7 @@
 <template lang="pug">
   .task
 
-    button.handle(
-    type="button")
+    .handle
       icon-drag
 
     // checkbox

--- a/src/components/task/task.vue
+++ b/src/components/task/task.vue
@@ -150,6 +150,7 @@
     position: relative;
     display: flex;
     align-items: flex-start;
+    background-color: #FFF;
 
     &.sortable-ghost {
       background-color: #EEFAFD;

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import App from './App'
 import store from './store'
 import moment from 'moment'
 import 'moment/locale/tr'
+import getFirefoxAuthToken from './utils/firefox-auth'
 
 import Draggable from 'vuedraggable'
 import VueQuillEditor from 'vue-quill-editor'
@@ -21,16 +22,20 @@ new Vue({
 }).$mount('#app')
 
 if (process.env.NODE_ENV === 'production') {
-  /* eslint-disable no-undef */
+  /* global chrome */
   window.onload = function () {
     console.info('production')
-    chrome.identity.getAuthToken(
-      { interactive: true },
-      async function (token) {
-        store.commit('calSetToken', token)
-        store.dispatch('getEventList')
-      }
-    )
+    if (process.env.VUE_APP_PLATFORM === 'firefox') {
+      getFirefoxAuthToken()
+    } else {
+      chrome.identity.getAuthToken(
+        { interactive: true },
+        async function (token) {
+          store.commit('calSetToken', token)
+          store.dispatch('getEventList')
+        }
+      )
+    }
   }
 } else {
   console.info('development')

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -27,7 +27,8 @@ export default new Vuex.Store({
       theme: 'bubble'
     },
     calendarList: [],
-    calendarItems: []
+    calendarItems: [],
+    firefoxToken: ''
   },
 
   getters: {
@@ -39,7 +40,8 @@ export default new Vuex.Store({
         (acc[key] || (acc[key] = [])).push(obj)
         return acc
       }, {})
-    }
+    },
+    hasFirefoxToken: state => !!state.firefoxToken
   },
 
   actions: {
@@ -73,6 +75,11 @@ export default new Vuex.Store({
 
       const response = await Promise.all(requestList)
       commit('setCalendarItems', response)
+    },
+
+    setTokenForFirefox ({ commit }, token) {
+      commit('firefoxSetToken', token)
+      commit('calSetToken', token)
     }
   },
 
@@ -128,6 +135,10 @@ export default new Vuex.Store({
       httpCal.defaults.headers.common.Authorization = `Bearer ${token}`
     },
 
+    firefoxSetToken (state, token) {
+      state.firefoxToken = token
+    },
+
     setCalendarList (state, data) {
       state.calendarList = data.items.map(item => new CalendarListItem(item))
     },
@@ -137,7 +148,6 @@ export default new Vuex.Store({
       const events = data.map(calendar => calendar.items)
       state.calendarItems = events.flat().map(event => new CalendarItem(event))
     }
-
   }
 
 })

--- a/src/utils/firefox-auth.js
+++ b/src/utils/firefox-auth.js
@@ -1,0 +1,54 @@
+/* global chrome */
+import httpCal from './http-calendar'
+import store from '../store'
+
+const authUrl = () => {
+  const manifest = chrome.runtime.getManifest()
+  const redirectUrl = chrome.identity.getRedirectURL()
+  console.info('redirect url', redirectUrl)
+
+  return [
+    'https://accounts.google.com/o/oauth2/auth',
+    '?client_id=' + manifest.oauth2.client_id,
+    '&response_type=token',
+    '&redirect_uri=' + encodeURIComponent(redirectUrl),
+    '&scope=' + manifest.oauth2.scopes.join(',')
+  ].join('')
+}
+
+const extractAccessToken = redirectUri => {
+  const m = redirectUri.match(/[#?](.*)/)
+  if (!m || m.length < 1) {
+    return null
+  }
+  const params = new URLSearchParams(m[1].split('#')[0])
+  return params.get('access_token')
+}
+
+const getAuthToken = () => {
+  if (store.getters.hasFirefoxToken) {
+    store.commit('calSetToken', store.firefoxToken)
+    store.dispatch('getEventList')
+  } else {
+    chrome.identity.launchWebAuthFlow({
+      interactive: true,
+      url: authUrl()
+    }, async redirectUri => {
+      const token = extractAccessToken(redirectUri)
+      store.dispatch('setTokenForFirefox', token)
+      store.dispatch('getEventList')
+
+      // Setting up an interceptor in case of a token expiration or unsuccessful
+      // authentication.
+      httpCal.interceptors.response.use(null, error => {
+        if (error.status === 401) {
+          store.dispatch('setTokenForFirefox', '')
+          getAuthToken()
+        }
+        return Promise.reject(error)
+      })
+    })
+  }
+}
+
+export default getAuthToken


### PR DESCRIPTION
There were some problems on various parts. Please see each commit messages for the problem explanations and fixes.
This will not work correctly unless we add redirect URL of the extension to Google API console. You can see the redirect url on the developer console when you open the new tab after installing the extension.
You can change the `client_id` in manifest file to `658048146602-dm9i4u3pl0hotu691jqjesa5sagg09h5.apps.googleusercontent.com` to be able to test the calendar.(But the redirect url may change and this client_id may become useless too. We have to publish the extension to get permanent redirect url, I guess.)

How to install temporary extension to test on Firefox:
1. Build the extension with `yarn build-firefox`.
2. Navigate to `about:debugging`.
3. Click to `Load Temporary Add-on` button.
4. Select the manifest file inside dist folder and click to `Open` button.

That was my first Vue experience btw. I didn't touch so many Vue files but nevertheless, it would be great if I can get some review comments if something doesn't look like what it supposed to.

Fixes #12.