### PR TITLE
Add auto scroll to .column and .columns

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -134,6 +134,7 @@
   .Columns {
     flex-grow: 1;
     display: flex;
+    overflow: auto;
     margin-left: -20px;
   }
 
@@ -142,6 +143,7 @@
     margin-left: 20px;
     display: flex;
     flex-direction: column;
+    overflow: auto;
     background-color: #FFF;
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .1);
     border-radius: 10px;


### PR DESCRIPTION
Resolves the issue #34 

Previously, overflowed content is not visible:
![frame_current](https://user-images.githubusercontent.com/968651/74631222-7c7be180-516d-11ea-9f3b-53fd0c407263.png)
 
With this change, scroll is added when the content overflows:
![frame_fix](https://user-images.githubusercontent.com/968651/74631273-a208eb00-516d-11ea-9ae4-c493b48b2ac3.png)
